### PR TITLE
ポートフォリオの修正

### DIFF
--- a/app/controllers/public/posts_controller.rb
+++ b/app/controllers/public/posts_controller.rb
@@ -129,27 +129,34 @@ class Public::PostsController < ApplicationController
   end
 
 
-  # 投稿を日時で絞り込む機能
+  # 投稿を日付で絞り込む機能
   def filter_by_date
-    @user = current_user
-    @posts = @user.posts
 
-    # params[:search_type]が存在する場合はその値を使用し、存在しない場合はデフォルトで "created_at" を設定する
-    @search_type = params[:search_type] || "created_at"
+    if params[:starting_date].blank? || params[:ending_date].blank?
+      flash[:error] = "絞り込む日付を入力してください。"
+      redirect_to request.referer
 
-    # params[:starting_date(:ending_date)]が存在してかつDate型になっていないならDate型にし、そうでないならそのままparamsのデータを使う
-    @starting_date = params[:starting_date].presence && !params[:starting_date].is_a?(Date) ? params[:starting_date].to_date : params[:starting_date]
-    @ending_date = params[:ending_date].presence && !params[:ending_date].is_a?(Date) ? params[:ending_date].to_date : params[:ending_date]
+    else
+      @user = current_user
+      @posts = @user.posts
 
-    @posts = if @search_type == "created_at"
-               @posts.where(created_at: @starting_date.beginning_of_day..@ending_date.end_of_day)
-             else
-               @posts.where(updated_at: @starting_date.beginning_of_day..@ending_date.end_of_day)
-             end
+      # params[:search_type]が存在する場合はその値を使用し、存在しない場合はデフォルトで "created_at" を設定する
+      @search_type = params[:search_type] || "created_at"
 
-    # 有効なユーザの投稿だけ表示
-    active_user_ids = User.where(is_active: true).pluck(:id)
-    @posts = @posts.where(user_id: active_user_ids).sorted_by(params)
+      # params[:starting_date(:ending_date)]が存在してかつDate型になっていないならDate型にし、そうでないならそのままparamsのデータを使う
+      @starting_date = params[:starting_date].presence && !params[:starting_date].is_a?(Date) ? params[:starting_date].to_date : params[:starting_date]
+      @ending_date = params[:ending_date].presence && !params[:ending_date].is_a?(Date) ? params[:ending_date].to_date : params[:ending_date]
+
+      @posts = if @search_type == "created_at"
+                 @posts.where(created_at: @starting_date.beginning_of_day..@ending_date.end_of_day)
+               else
+                 @posts.where(updated_at: @starting_date.beginning_of_day..@ending_date.end_of_day)
+               end
+
+      # 有効なユーザの投稿だけ表示
+      active_user_ids = User.where(is_active: true).pluck(:id)
+      @posts = @posts.where(user_id: active_user_ids).sorted_by(params)
+    end
   end
 
   private

--- a/app/controllers/public/posts_controller.rb
+++ b/app/controllers/public/posts_controller.rb
@@ -64,7 +64,8 @@ class Public::PostsController < ApplicationController
 
   # postモデル内にbefore_updateコールバックあり(ハッシュタグを更新するため)
   def update
-    @post = Post.find(params[:id])
+    # 自身の投稿のみ取得（他のユーザの投稿は更新できない）
+    @post = current_user.posts.find(params[:id])
 
     if @post.update(post_params)
       flash[:success] = "投稿内容を変更しました。"
@@ -78,7 +79,9 @@ class Public::PostsController < ApplicationController
 
 
   def destroy
-    @post = Post.find(params[:id])
+    # 自身の投稿のみ取得（他のユーザの投稿は削除できない）
+    @post = current_user.posts.find(params[:id])
+
     @post.destroy
     flash[:notice] = "投稿を削除しました。"
     redirect_to user_path(current_user)

--- a/app/controllers/public/users_controller.rb
+++ b/app/controllers/public/users_controller.rb
@@ -26,22 +26,13 @@ class Public::UsersController < ApplicationController
     end
   end
 
-
-  def edit
-    @user = User.find_by(id: params[:id])
-
-    if @user.nil?
-      flash[:error] = "ページが存在しません。"
-      redirect_to posts_path
-
-    elsif @user != current_user
-      flash[:error] = "禁止された操作です。"
-      redirect_to posts_path
-    end
+  # プロフィール情報編集画面
+  def edit_profile
+    @user = current_user
   end
 
-
-  def update
+  # プロフィール情報更新処理
+  def update_profile
     # 自身の情報のみ取得（他のユーザの情報は更新できない）
     @user = current_user
 
@@ -51,7 +42,7 @@ class Public::UsersController < ApplicationController
 
     else
       flash.now[:alert] = "変更に失敗しました。"
-      render :edit
+      render :edit_profile
     end
   end
 

--- a/app/controllers/public/users_controller.rb
+++ b/app/controllers/public/users_controller.rb
@@ -42,7 +42,8 @@ class Public::UsersController < ApplicationController
 
 
   def update
-    @user = User.find(params[:id])
+    # 自身の情報のみ取得（他のユーザの情報は更新できない）
+    @user = current_user
 
     if @user.update(user_params)
       flash[:success] = "プロフィールを変更しました。"

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -211,6 +211,12 @@ a:hover {
   border-bottom: 2px solid #f8f9fa;
 }
 
+// クリックやタッチを無効化する
+.click-disabled-css {
+  pointer-events: none;
+  opacity: 0.5;
+}
+
 // 投稿詳細画面のアイコンボタン
 .fontawesome-button {
   font-size: 25px;

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,6 +27,12 @@ class User < ApplicationRecord
   end
 
 
+  # ユーザがゲストであるかを確認するメソッド。
+  def guest?
+    self.email == "guest@example.com"
+  end
+
+
   # ゲストログイン機能。パスワードはランダムに作られる。
   def self.guest
     find_or_create_by!(email: 'guest@example.com') do |user|

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -49,7 +49,7 @@
           <% end %>
         </li>
         <li>
-          <%= link_to edit_user_path(current_user), class: "pb-1 py-sm-3" do %>
+          <%= link_to edit_profile_users_path, class: "pb-1 py-sm-3" do %>
             <i class="fas fa-user-gear"></i> プロフィール編集
           <% end %>
         </li>

--- a/app/views/public/users/edit_profile.html.erb
+++ b/app/views/public/users/edit_profile.html.erb
@@ -8,7 +8,7 @@
           プロフィール編集
           <i class="fas fa-user-gear"></i>
         </h5>
-        <%= form_with model: @user, url: user_path do |f| %>
+        <%= form_with model: @user, url: update_profile_users_path, method: :put do |f| %>
           <%= render "public/shared/error_messages", resource: @user %>
 
           <div class="form-group">
@@ -30,14 +30,24 @@
             <%= f.label :email, "登録メールアドレス" %><br>
             <%= f.text_field :email, placeholder: "abc@stechao.com", class: 'form-control' %>
           </div>
-          <p>メールアドレスは他の人には表示されません。</p>
+          <p>
+            <i class="fas fa-circle-exclamation"></i> メールアドレスは他の人には表示されません。
+          </p>
 
-          <div class="form-group text-center">
-            <%= f.submit "変更する", class: 'btn btn-success' %>
-          </div>
-
-          <% if user_signed_in? && @user.id == current_user.id %>
-            <%= link_to "退会する", withdraw_user_path(current_user), method: :put, data: { confirm: "本当に退会しますか？" }, class: "btn btn-danger" %>
+          <!--ログインユーザがゲストの場合、変更ボタンを非アクティブ・退会ボタンを非表示-->
+          <% if current_user.guest? %>
+            <div class="form-group text-center">
+              <%= f.submit "変更する", class: 'btn btn-success click-disabled-css' %>
+            </div>
+            <p>
+              <i class="fas fa-circle-exclamation"></i> ゲストユーザーは変更・退会できません。
+            </p>
+          <!--ログインユーザがゲスト以外の場合、変更ボタンをアクティブ・退会ボタンを表示-->
+          <% else %>
+            <div class="form-group text-center">
+              <%= f.submit "変更する", class: 'btn btn-success' %>
+            </div>
+            <%= link_to "退会する", withdraw_user_path(current_user), method: :patch, data: { confirm: "本当に退会しますか？" }, class: "btn btn-danger" %>
           <% end %>
         <% end %>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,10 +36,15 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :users, only: [:index, :show, :edit, :update] do
+    resources :users, only: [:index, :show] do
+      collection do
+        get :edit_profile
+        put :update_profile
+      end
+
       member do
         get :favorites
-        put :withdraw
+        patch :withdraw
       end
     end
 


### PR DESCRIPTION
・投稿を日付で絞り込む際、フォームが空白のまま検索ボタンを押すとエラーになる問題を修正。
・post#update, post#destroyの投稿データ、user#updateのユーザデータを取得する際、
current_userのデータのみを取得するように修正（他のユーザのデータをいじれないようにするため）。
・user#edit, user#updateのURLにidが含まれないように修正（current_userの情報編集だけで良いため）。
・ゲストはプロフィール編集や退会ができないように修正。